### PR TITLE
Add MCP best practices: tool naming and annotations

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -113,6 +113,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     properties: {},
                     required: [],
                 },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_todays_tasks",
@@ -142,7 +148,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         }
                     },
                     required: [],
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_schedule_activity",
@@ -176,7 +188,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         }
                     },
                     required: ["activity_type_id", "created_at"]
-                }
+                },
+                annotations: {
+                    readOnlyHint: false,
+                    destructiveHint: false,
+                    idempotentHint: false,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_search_candidates",
@@ -221,7 +239,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                             description: "Include results from related agencies."
                         }
                     }
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_candidate",
@@ -235,7 +259,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         }
                     },
                     required: ["id"]
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_person_emails",
@@ -246,6 +276,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         id: { type: "string", description: "The ID of the person." } // Reusing 'id' from EntityIdSchema
                     },
                     required: ["id"],
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
                 },
             },
             {
@@ -258,6 +294,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     },
                     required: ["id"],
                 },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_list_person_job_profiles",
@@ -268,7 +310,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         id: { type: "string", description: "The ID of the person." }
                     },
                     required: ["id"],
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_person_job_profile_detail",
@@ -280,7 +328,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         resource_id: { type: "string", description: "The ID of the job profile." }
                     },
                     required: ["person_id", "resource_id"],
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_list_person_education_profiles",
@@ -291,7 +345,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         id: { type: "string", description: "The ID of the person." }
                     },
                     required: ["id"],
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_person_education_profile_detail",
@@ -303,7 +363,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         resource_id: { type: "string", description: "The ID of the education profile." }
                     },
                     required: ["person_id", "resource_id"],
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_search_jobs",
@@ -324,7 +390,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                             description: "Number of results per page"
                         }
                     }
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_job",
@@ -338,7 +410,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         }
                     },
                     required: ["id"]
-                }
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_log_activity",
@@ -368,7 +446,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                         }
                     },
                     required: ["activity_type_id"]
-                }
+                },
+                annotations: {
+                    readOnlyHint: false,
+                    destructiveHint: false,
+                    idempotentHint: false,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_search_companies",
@@ -384,6 +468,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     },
                     required: [],
                 },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_get_company_details",
@@ -395,6 +485,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     },
                     required: ["company_id"],
                 },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                },
             },
             {
                 name: "loxo_list_users",
@@ -403,6 +499,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     type: "object",
                     properties: {},
                     required: [],
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
                 },
             }
         ]

--- a/build/index.js
+++ b/build/index.js
@@ -106,7 +106,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
         tools: [
             {
-                name: "get-activity-types",
+                name: "loxo_get_activity_types",
                 description: "Get a list of activity types from Loxo",
                 inputSchema: {
                     type: "object",
@@ -115,7 +115,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
-                name: "get-todays-tasks",
+                name: "loxo_get_todays_tasks",
                 description: "Get all tasks and scheduled activities for today or a date range",
                 inputSchema: {
                     type: "object",
@@ -145,7 +145,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "schedule-activity",
+                name: "loxo_schedule_activity",
                 description: "Schedule a future activity (like a call or meeting) by creating a person event",
                 inputSchema: {
                     type: "object",
@@ -179,7 +179,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "search-candidates",
+                name: "loxo_search_candidates",
                 description: "Search for candidates in Loxo. Use the 'query' field for complex Lucene queries, including searching past employment (e.g., 'job_profiles.company_name:\"Old Company\"'). The 'company' parameter targets current employment.",
                 inputSchema: {
                     type: "object",
@@ -224,7 +224,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "get-candidate",
+                name: "loxo_get_candidate",
                 description: "Get detailed information from a candidate's main profile. This may include summaries or full lists of job/education profiles. For guaranteed complete lists and then full details of each item, use list-person-job-profiles, get-person-job-profile-detail, etc., and similarly for education, emails, and phones.",
                 inputSchema: {
                     type: "object",
@@ -238,7 +238,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "get-person-emails",
+                name: "loxo_get_person_emails",
                 description: "Get all email addresses for a specific person.",
                 inputSchema: {
                     type: "object",
@@ -249,7 +249,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
-                name: "get-person-phones",
+                name: "loxo_get_person_phones",
                 description: "Get all phone numbers for a specific person.",
                 inputSchema: {
                     type: "object",
@@ -260,7 +260,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
-                name: "list-person-job-profiles",
+                name: "loxo_list_person_job_profiles",
                 description: "Lists job profiles (work history summaries/IDs) for a person. Use get-person-job-profile-detail for full details of each.",
                 inputSchema: {
                     type: "object",
@@ -271,7 +271,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "get-person-job-profile-detail",
+                name: "loxo_get_person_job_profile_detail",
                 description: "Get full details for a specific job profile (work history item) of a person.",
                 inputSchema: {
                     type: "object",
@@ -283,7 +283,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "list-person-education-profiles",
+                name: "loxo_list_person_education_profiles",
                 description: "Lists education profiles (summaries/IDs) for a person. Use get-person-education-profile-detail for full details of each.",
                 inputSchema: {
                     type: "object",
@@ -294,7 +294,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "get-person-education-profile-detail",
+                name: "loxo_get_person_education_profile_detail",
                 description: "Get full details for a specific education profile item of a person.",
                 inputSchema: {
                     type: "object",
@@ -306,7 +306,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "search-jobs",
+                name: "loxo_search_jobs",
                 description: "Search for jobs in Loxo using page-based pagination",
                 inputSchema: {
                     type: "object",
@@ -327,7 +327,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "get-job",
+                name: "loxo_get_job",
                 description: "Get detailed information about a specific job",
                 inputSchema: {
                     type: "object",
@@ -341,7 +341,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "log-activity",
+                name: "loxo_log_activity",
                 description: "Log a completed activity by creating a person event (logged with current timestamp)",
                 inputSchema: {
                     type: "object",
@@ -371,7 +371,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 }
             },
             {
-                name: "search-companies",
+                name: "loxo_search_companies",
                 description: "Search for companies in Loxo.",
                 inputSchema: {
                     type: "object",
@@ -386,7 +386,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
-                name: "get-company-details",
+                name: "loxo_get_company_details",
                 description: "Get detailed information about a specific company.",
                 inputSchema: {
                     type: "object",
@@ -397,7 +397,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
             },
             {
-                name: "list-users",
+                name: "loxo_list_users",
                 description: "Get a list of users in the Loxo agency.",
                 inputSchema: {
                     type: "object",
@@ -413,13 +413,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
     try {
         switch (name) {
-            case "get-activity-types": {
+            case "loxo_get_activity_types": {
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/activity_types`);
                 return {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "get-todays-tasks": {
+            case "loxo_get_todays_tasks": {
                 const { user_id, start_date, end_date, per_page, scroll_id } = args;
                 let searchParams = new URLSearchParams();
                 if (user_id)
@@ -440,7 +440,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                         }]
                 };
             }
-            case "schedule-activity": {
+            case "loxo_schedule_activity": {
                 const { person_id, job_id, company_id, activity_type_id, created_at, notes } = PersonEventSchema.parse(args);
                 const formData = new URLSearchParams();
                 if (person_id)
@@ -466,7 +466,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                         }]
                 };
             }
-            case "search-candidates": {
+            case "loxo_search_candidates": {
                 const { query, company, title, scroll_id, per_page, person_global_status_id, person_type_id, list_id, include_related_agencies } = SearchCandidatesSchema.parse(args); // Use the new specific schema
                 let searchParams = new URLSearchParams();
                 if (per_page)
@@ -532,14 +532,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     };
                 }
             }
-            case "get-candidate": {
+            case "loxo_get_candidate": {
                 const { id } = EntityIdSchema.parse(args);
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/people/${id}`);
                 return {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "search-jobs": {
+            case "loxo_search_jobs": {
                 const { query, per_page, page } = args;
                 // Build search params
                 let searchParams = new URLSearchParams();
@@ -557,14 +557,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                         }]
                 };
             }
-            case "get-job": {
+            case "loxo_get_job": {
                 const { id } = EntityIdSchema.parse(args);
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/jobs/${id}`);
                 return {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "log-activity": {
+            case "loxo_log_activity": {
                 const { person_id, job_id, company_id, activity_type_id, notes } = PersonEventSchema.parse(args);
                 const formData = new URLSearchParams();
                 if (person_id)
@@ -585,7 +585,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "search-companies": {
+            case "loxo_search_companies": {
                 const { query, scroll_id, company_type_id, list_id, company_global_status_id } = SearchCompaniesSchema.parse(args);
                 let searchParams = new URLSearchParams();
                 if (query)
@@ -603,7 +603,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "get-company-details": {
+            case "loxo_get_company_details": {
                 const { company_id } = GetCompanyDetailsSchema.parse(args);
                 const response = await makeRequest(// Assuming a single Company object is returned
                 `/${env.LOXO_AGENCY_SLUG}/companies/${company_id}`);
@@ -611,7 +611,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "list-users": {
+            case "loxo_list_users": {
                 // ListUsersSchema is empty, so no args to parse specifically for it.
                 const response = await makeRequest(// Assuming a ListUsersResponse object
                 `/${env.LOXO_AGENCY_SLUG}/users`);
@@ -619,21 +619,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "get-person-emails": {
+            case "loxo_get_person_emails": {
                 const { id: person_id } = EntityIdSchema.parse(args); // 'id' from input is person_id
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/emails`);
                 return {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "get-person-phones": {
+            case "loxo_get_person_phones": {
                 const { id: person_id } = EntityIdSchema.parse(args);
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/phones`);
                 return {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "list-person-job-profiles": {
+            case "loxo_list_person_job_profiles": {
                 const { id: person_id } = EntityIdSchema.parse(args);
                 // Assuming this endpoint returns an array of full JobProfile objects for now.
                 // If it returns summaries/IDs, the response type <JobProfile[]> might need adjustment.
@@ -642,14 +642,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "get-person-job-profile-detail": {
+            case "loxo_get_person_job_profile_detail": {
                 const { person_id, resource_id: job_profile_id } = PersonSubResourceIdSchema.parse(args);
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/job_profiles/${job_profile_id}`);
                 return {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "list-person-education-profiles": {
+            case "loxo_list_person_education_profiles": {
                 const { id: person_id } = EntityIdSchema.parse(args);
                 // Assuming this endpoint returns an array of full EducationProfile objects for now.
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/education_profiles`);
@@ -657,7 +657,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
                 };
             }
-            case "get-person-education-profile-detail": {
+            case "loxo_get_person_education_profile_detail": {
                 const { person_id, resource_id: education_profile_id } = PersonSubResourceIdSchema.parse(args);
                 const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/education_profiles/${education_profile_id}`);
                 return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       {
-        name: "get-activity-types",
+        name: "loxo_get_activity_types",
         description: "Get a list of activity types from Loxo",
         inputSchema: {
           type: "object",
@@ -334,7 +334,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "get-todays-tasks",
+        name: "loxo_get_todays_tasks",
         description: "Get all tasks and scheduled activities for today or a date range",
         inputSchema: {
           type: "object",
@@ -364,7 +364,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "schedule-activity",
+        name: "loxo_schedule_activity",
         description: "Schedule a future activity (like a call or meeting) by creating a person event",
         inputSchema: {
           type: "object",
@@ -398,7 +398,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "search-candidates",
+        name: "loxo_search_candidates",
         description: "Search for candidates in Loxo. Use the 'query' field for complex Lucene queries, including searching past employment (e.g., 'job_profiles.company_name:\"Old Company\"'). The 'company' parameter targets current employment.",
         inputSchema: {
           type: "object",
@@ -443,7 +443,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "get-candidate",
+        name: "loxo_get_candidate",
         description: "Get detailed information from a candidate's main profile. This may include summaries or full lists of job/education profiles. For guaranteed complete lists and then full details of each item, use list-person-job-profiles, get-person-job-profile-detail, etc., and similarly for education, emails, and phones.",
         inputSchema: {
           type: "object",
@@ -457,7 +457,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "get-person-emails",
+        name: "loxo_get_person_emails",
         description: "Get all email addresses for a specific person.",
         inputSchema: {
           type: "object",
@@ -468,7 +468,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "get-person-phones",
+        name: "loxo_get_person_phones",
         description: "Get all phone numbers for a specific person.",
         inputSchema: {
           type: "object",
@@ -479,7 +479,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "list-person-job-profiles",
+        name: "loxo_list_person_job_profiles",
         description: "Lists job profiles (work history summaries/IDs) for a person. Use get-person-job-profile-detail for full details of each.",
         inputSchema: {
           type: "object",
@@ -490,7 +490,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "get-person-job-profile-detail",
+        name: "loxo_get_person_job_profile_detail",
         description: "Get full details for a specific job profile (work history item) of a person.",
         inputSchema: {
           type: "object",
@@ -502,7 +502,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "list-person-education-profiles",
+        name: "loxo_list_person_education_profiles",
         description: "Lists education profiles (summaries/IDs) for a person. Use get-person-education-profile-detail for full details of each.",
         inputSchema: {
           type: "object",
@@ -513,7 +513,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "get-person-education-profile-detail",
+        name: "loxo_get_person_education_profile_detail",
         description: "Get full details for a specific education profile item of a person.",
         inputSchema: {
           type: "object",
@@ -525,7 +525,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "search-jobs",
+        name: "loxo_search_jobs",
         description: "Search for jobs in Loxo using page-based pagination",
         inputSchema: {
           type: "object",
@@ -546,7 +546,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "get-job",
+        name: "loxo_get_job",
         description: "Get detailed information about a specific job",
         inputSchema: {
           type: "object",
@@ -560,7 +560,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "log-activity",
+        name: "loxo_log_activity",
         description: "Log a completed activity by creating a person event (logged with current timestamp)",
         inputSchema: {
           type: "object",
@@ -590,7 +590,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         }
       },
       {
-        name: "search-companies",
+        name: "loxo_search_companies",
         description: "Search for companies in Loxo.",
         inputSchema: {
           type: "object",
@@ -605,7 +605,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "get-company-details",
+        name: "loxo_get_company_details",
         description: "Get detailed information about a specific company.",
         inputSchema: {
           type: "object",
@@ -616,7 +616,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "list-users",
+        name: "loxo_list_users",
         description: "Get a list of users in the Loxo agency.",
         inputSchema: {
           type: "object",
@@ -634,14 +634,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   try {
     switch (name) {
-      case "get-activity-types": {
+      case "loxo_get_activity_types": {
         const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/activity_types`);
         return {
           content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
         };
       }
 
-      case "get-todays-tasks": {
+      case "loxo_get_todays_tasks": {
         const { user_id, start_date, end_date, per_page, scroll_id } = args as any;
 
         let searchParams = new URLSearchParams();
@@ -662,7 +662,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "schedule-activity": {
+      case "loxo_schedule_activity": {
         const { person_id, job_id, company_id, activity_type_id, created_at, notes } = PersonEventSchema.parse(args);
 
         const formData = new URLSearchParams();
@@ -689,7 +689,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "search-candidates": {
+      case "loxo_search_candidates": {
         const { 
             query, 
             company, 
@@ -769,7 +769,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
     }
 
-      case "get-candidate": {
+      case "loxo_get_candidate": {
         const { id } = EntityIdSchema.parse(args);
         const response = await makeRequest<Candidate>(`/${env.LOXO_AGENCY_SLUG}/people/${id}`);
         return {
@@ -777,7 +777,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "search-jobs": {
+      case "loxo_search_jobs": {
         const { query, per_page, page } = args as any;
 
         // Build search params
@@ -798,7 +798,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "get-job": {
+      case "loxo_get_job": {
         const { id } = EntityIdSchema.parse(args);
         const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/jobs/${id}`);
         return {
@@ -806,7 +806,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "log-activity": {
+      case "loxo_log_activity": {
         const { person_id, job_id, company_id, activity_type_id, notes } = PersonEventSchema.parse(args);
 
         const formData = new URLSearchParams();
@@ -829,7 +829,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "search-companies": {
+      case "loxo_search_companies": {
         const { 
           query, 
           scroll_id, 
@@ -853,7 +853,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "get-company-details": {
+      case "loxo_get_company_details": {
         const { company_id } = GetCompanyDetailsSchema.parse(args);
         const response = await makeRequest<Company>( // Assuming a single Company object is returned
           `/${env.LOXO_AGENCY_SLUG}/companies/${company_id}`
@@ -863,7 +863,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "list-users": {
+      case "loxo_list_users": {
         // ListUsersSchema is empty, so no args to parse specifically for it.
         const response = await makeRequest<ListUsersResponse>( // Assuming a ListUsersResponse object
           `/${env.LOXO_AGENCY_SLUG}/users`
@@ -873,7 +873,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "get-person-emails": {
+      case "loxo_get_person_emails": {
         const { id: person_id } = EntityIdSchema.parse(args); // 'id' from input is person_id
         const response = await makeRequest<EmailInfo[]>(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/emails`);
         return {
@@ -881,7 +881,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "get-person-phones": {
+      case "loxo_get_person_phones": {
         const { id: person_id } = EntityIdSchema.parse(args); 
         const response = await makeRequest<PhoneInfo[]>(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/phones`);
         return {
@@ -889,7 +889,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "list-person-job-profiles": {
+      case "loxo_list_person_job_profiles": {
         const { id: person_id } = EntityIdSchema.parse(args);
         // Assuming this endpoint returns an array of full JobProfile objects for now.
         // If it returns summaries/IDs, the response type <JobProfile[]> might need adjustment.
@@ -899,7 +899,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "get-person-job-profile-detail": {
+      case "loxo_get_person_job_profile_detail": {
         const { person_id, resource_id: job_profile_id } = PersonSubResourceIdSchema.parse(args);
         const response = await makeRequest<JobProfile>(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/job_profiles/${job_profile_id}`);
         return {
@@ -907,7 +907,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "list-person-education-profiles": {
+      case "loxo_list_person_education_profiles": {
         const { id: person_id } = EntityIdSchema.parse(args);
         // Assuming this endpoint returns an array of full EducationProfile objects for now.
         const response = await makeRequest<EducationProfile[]>(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/education_profiles`);
@@ -916,7 +916,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "get-person-education-profile-detail": {
+      case "loxo_get_person_education_profile_detail": {
         const { person_id, resource_id: education_profile_id } = PersonSubResourceIdSchema.parse(args);
         const response = await makeRequest<EducationProfile>(`/${env.LOXO_AGENCY_SLUG}/people/${person_id}/education_profiles/${education_profile_id}`);
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,6 +332,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {},
           required: [],
         },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_todays_tasks",
@@ -361,7 +367,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             }
           },
           required: [],
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_schedule_activity",
@@ -395,7 +407,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             }
           },
           required: ["activity_type_id", "created_at"]
-        }
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_search_candidates",
@@ -440,7 +458,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 description: "Include results from related agencies."
             }
           }
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_candidate",
@@ -454,7 +478,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             }
           },
           required: ["id"]
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_person_emails",
@@ -466,6 +496,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ["id"],
         },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_person_phones",
@@ -473,9 +509,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: {
           type: "object",
           properties: {
-            id: { type: "string", description: "The ID of the person." } 
+            id: { type: "string", description: "The ID of the person." }
           },
           required: ["id"],
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
         },
       },
       {
@@ -487,7 +529,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             id: { type: "string", description: "The ID of the person."}
           },
           required: ["id"],
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_person_job_profile_detail",
@@ -499,7 +547,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             resource_id: { type: "string", description: "The ID of the job profile." }
           },
           required: ["person_id", "resource_id"],
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_list_person_education_profiles",
@@ -510,7 +564,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             id: { type: "string", description: "The ID of the person." }
           },
           required: ["id"],
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_person_education_profile_detail",
@@ -522,7 +582,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             resource_id: { type: "string", description: "The ID of the education profile." }
           },
           required: ["person_id", "resource_id"],
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_search_jobs",
@@ -543,7 +609,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Number of results per page"
             }
           }
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_job",
@@ -557,7 +629,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             }
           },
           required: ["id"]
-        }
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_log_activity",
@@ -587,7 +665,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             }
           },
           required: ["activity_type_id"]
-        }
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_search_companies",
@@ -603,6 +687,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: [],
         },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_get_company_details",
@@ -614,6 +704,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ["company_id"],
         },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
       },
       {
         name: "loxo_list_users",
@@ -622,6 +718,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: {},
           required: [],
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
         },
       }
     ]


### PR DESCRIPTION
## Summary

Phase 2 of MCP server improvements: Implement MCP best practices for tool naming and metadata annotations to improve discoverability and AI assistant understanding.

## Changes

### 1. Tool Naming with Prefix (MCP Best Practice)

Added `loxo_` prefix to all 17 tools to prevent naming conflicts when multiple MCP servers are used together.

**Before → After:**
- `get-activity-types` → `loxo_get_activity_types`
- `get-todays-tasks` → `loxo_get_todays_tasks`
- `schedule-activity` → `loxo_schedule_activity`
- `search-candidates` → `loxo_search_candidates`
- `get-candidate` → `loxo_get_candidate`
- `get-person-emails` → `loxo_get_person_emails`
- `get-person-phones` → `loxo_get_person_phones`
- `list-person-job-profiles` → `loxo_list_person_job_profiles`
- `get-person-job-profile-detail` → `loxo_get_person_job_profile_detail`
- `list-person-education-profiles` → `loxo_list_person_education_profiles`
- `get-person-education-profile-detail` → `loxo_get_person_education_profile_detail`
- `search-jobs` → `loxo_search_jobs`
- `get-job` → `loxo_get_job`
- `log-activity` → `loxo_log_activity`
- `search-companies` → `loxo_search_companies`
- `get-company-details` → `loxo_get_company_details`
- `list-users` → `loxo_list_users`

### 2. Tool Annotations (MCP Best Practice)

Added metadata annotations to all tools to help AI assistants understand tool characteristics:

**Annotation Types:**
- `readOnlyHint`: Indicates if tool only reads data (true for GET operations)
- `destructiveHint`: Indicates if tool deletes/destroys data (false for all our tools)
- `idempotentHint`: Indicates if repeated calls have same effect (true for reads, false for creates)
- `openWorldHint`: Indicates interaction with external systems (true for all our tools)

**Read-Only Tools (15):**
All GET/search/list operations with:
- `readOnlyHint: true`
- `idempotentHint: true`
- `destructiveHint: false`
- `openWorldHint: true`

**Create Tools (2):**
Activity logging/scheduling operations with:
- `readOnlyHint: false`
- `idempotentHint: false` (creates new records each time)
- `destructiveHint: false`
- `openWorldHint: true`

## Benefits

1. **Namespace Safety**: Tool names are now unique across MCP servers
2. **Better AI Understanding**: Annotations help AI assistants:
   - Identify safe read-only operations
   - Understand which operations create new data
   - Know all operations interact with external API
3. **Improved User Experience**: AI can make better decisions about when/how to use tools

## Verification

✅ All 17 tools renamed with `loxo_` prefix
✅ All 17 tools have complete annotations
✅ All case statements updated
✅ Build successful: `npm run build`
✅ TypeScript compilation with no errors

## Next Steps (Future PRs)

Remaining Phase 2 improvements:
- Add `response_format` parameter (json/markdown)
- Implement CHARACTER_LIMIT and truncation logic
- Enhance tool descriptions with usage examples
- Improve error messages to be actionable
- Add pagination metadata to responses
- Create evaluation harness

## Related

Part of Phase 2 improvements outlined in `.claudedocs/oas-analysis-and-implementation-plan.md`