### PR TITLE
fix: API fixes & new tools for recruiter workflow (v1.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 package-lock.json
 .api
 node_modules
+.worktrees

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loxo-mcp-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "main": "build/index.js",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -426,6 +426,12 @@ const UpdateCandidateSchema = z.object({
   source_type_id: z.number().int().optional().describe("Source type ID. E.g. 1206583=LinkedIn, 1206592=API. Use loxo_list_source_types to discover."),
 });
 
+const AddToPipelineSchema = z.object({
+  job_id: z.string().regex(/^\d+$/, "job_id must be numeric").describe("The job ID to add the candidate to."),
+  person_id: z.string().regex(/^\d+$/, "person_id must be numeric").describe("The candidate's person ID."),
+  notes: z.string().optional().describe("Optional notes (e.g. 'Sourced from LinkedIn applications')."),
+});
+
 type PersonEventArgs = z.infer<typeof PersonEventSchema>;
 type SearchArgs = z.infer<typeof SearchSchema>; // Generic search, might deprecate if specific ones cover all uses
 type TypeSearchCandidatesArgs = z.infer<typeof SearchCandidatesSchema>;
@@ -828,7 +834,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "loxo_log_activity",
-        description: "Log a completed activity (call, email, interview) that already happened. Uses current timestamp automatically. Use loxo_get_activity_types first to get correct activity_type_id. Example: Just finished phone screen with candidate - log it with activity_type_id for 'phone screen', person_id, and notes about the conversation. Optionally link to job_id or company_id.",
+        description: "Log a completed activity (call, email, interview) that already happened. Uses current timestamp automatically. Use loxo_get_activity_types first to get correct activity_type_id. Example: Just finished phone screen with candidate - log it with activity_type_id for 'phone screen', person_id, and notes about the conversation. Optionally link to job_id or company_id. Note: activity_type_id=1550055 ('Added to Job') adds candidates to a job pipeline — for that, prefer loxo_add_to_pipeline which handles the correct type automatically.",
         inputSchema: {
           type: "object",
           properties: {
@@ -1015,14 +1021,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
-        name: "loxo_apply_to_job",
-        description: "Add a candidate to a job's pipeline. Use after identifying a good candidate match to assign them to a role. Example: After searching for and finding a suitable candidate, call this to add them to the job pipeline so they appear in loxo_get_job_pipeline.",
+        name: "loxo_add_to_pipeline",
+        description: "Add a candidate to a job's pipeline. Creates an 'Added to Job' activity event which places the candidate in the pipeline at the first stage. Use after identifying a good candidate match. The candidate will then appear in loxo_get_job_pipeline results. Note: this is NOT the same as loxo_log_activity — this tool specifically handles pipeline addition with the correct activity type.",
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
         inputSchema: {
           type: "object",
           properties: {
             job_id: { type: "string", description: "The job ID (required)." },
             person_id: { type: "string", description: "The candidate's person ID (required)." },
+            notes: { type: "string", description: "Optional notes about why the candidate was added." },
           },
           required: ["job_id", "person_id"],
         },
@@ -1592,16 +1599,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return { content: [{ type: "text", text }] };
       }
 
-      case "loxo_apply_to_job": {
-        const { job_id, person_id } = args as any;
-        requireNumericId(job_id, 'job_id');
-        requireNumericId(person_id, 'person_id');
+      case "loxo_add_to_pipeline": {
+        const { job_id, person_id, notes } = AddToPipelineSchema.parse(args);
 
         const formData = new URLSearchParams();
-        formData.append('person_id', person_id.toString());
+        formData.append('person_event[person_id]', person_id);
+        formData.append('person_event[job_id]', job_id);
+        formData.append('person_event[activity_type_id]', '1550055'); // "Added to Job"
+        if (notes) formData.append('person_event[notes]', notes);
 
         const response = await makeRequest(
-          `/${env.LOXO_AGENCY_SLUG}/jobs/${job_id}/contacts`,
+          `/${env.LOXO_AGENCY_SLUG}/person_events`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/src/server.ts
+++ b/src/server.ts
@@ -409,8 +409,6 @@ const CreateCandidateSchema = z.object({
   current_title: z.string().optional().describe("Current job title."),
   current_company: z.string().optional().describe("Current employer name."),
   location: z.string().optional().describe("City, region, or country."),
-  person_type_id: z.number().int().optional().describe("Person type ID. Use to flag CV-sourced candidates (e.g. Prospect type) to prevent polluting active pipelines. Get valid IDs from loxo_list_users or Loxo settings."),
-  tags: z.string().optional().describe("Comma-separated tags to apply (e.g. 'cv-import,sourced-march-2026')."),
 });
 
 const UpdateCandidateSchema = z.object({
@@ -932,7 +930,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "loxo_create_candidate",
-        description: "Create a new candidate record in Loxo. Primary use case: after Claude parses a downloaded CV, call this to add the person to the database. Use person_type_id to assign a 'Prospect' or similar type so the candidate doesn't appear in active pipeline searches until qualified. Example: After parsing a CV, create with name, email, current_title, current_company, and person_type_id=<prospect_type_id>.",
+        description: "Create a new candidate record in Loxo with name, contact info, and current role. Source type is auto-set to 'API'. After creating, use loxo_update_candidate to set tags, skillsets, person_type, source_type, and sector — these fields require a separate PUT call. Example workflow: (1) loxo_create_candidate with name/email/phone/title/company, (2) loxo_update_candidate to add tags and skillset, (3) loxo_add_to_pipeline to add to a job.",
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
         inputSchema: {
           type: "object",
@@ -943,8 +941,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             current_title: { type: "string", description: "Current job title." },
             current_company: { type: "string", description: "Current employer." },
             location: { type: "string", description: "City, region, or country." },
-            person_type_id: { type: "number", description: "Person type ID for categorisation (e.g. Prospect). Use to prevent pipeline pollution." },
-            tags: { type: "string", description: "Comma-separated tags (e.g. 'cv-import,march-2026')." },
           },
           required: ["name"],
         },
@@ -1421,17 +1417,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "loxo_create_candidate": {
-        const { name, email, phone, current_title, current_company, location, person_type_id, tags } = CreateCandidateSchema.parse(args);
+        const { name, email, phone, current_title, current_company, location } = CreateCandidateSchema.parse(args);
 
         const formData = new URLSearchParams();
         formData.append('person[name]', name);
-        if (email) formData.append('person[email_addresses][][value]', email);
-        if (phone) formData.append('person[phone_numbers][][value]', phone);
+        if (email) formData.append('person[email]', email);
+        if (phone) formData.append('person[phone]', phone);
         if (current_title) formData.append('person[title]', current_title);
         if (current_company) formData.append('person[company]', current_company);
         if (location) formData.append('person[location]', location);
-        if (person_type_id) formData.append('person[person_type_ids][]', person_type_id.toString());
-        if (tags) formData.append('person[tag_list]', tags);
 
         const response = await makeRequest(
           `/${env.LOXO_AGENCY_SLUG}/people`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -414,13 +414,16 @@ const CreateCandidateSchema = z.object({
 const UpdateCandidateSchema = z.object({
   id: z.string().regex(/^\d+$/, "ID must be numeric").describe("The candidate's person ID."),
   name: z.string().optional().describe("Full name."),
-  email: z.string().optional().describe("Primary email address."),
-  phone: z.string().optional().describe("Primary phone number."),
+  email: z.string().optional().describe("Email address to add."),
+  phone: z.string().optional().describe("Phone number to add."),
   current_title: z.string().optional().describe("Current job title."),
   current_company: z.string().optional().describe("Current employer name."),
   location: z.string().optional().describe("City, region, or country."),
-  person_type_id: z.number().int().optional().describe("Person type ID."),
-  tags: z.string().optional().describe("Comma-separated tags to apply."),
+  tags: z.array(z.string()).optional().describe("Tags to set (replaces existing). E.g. ['cv-import', 'debt-advisory']."),
+  skillset_ids: z.array(z.number().int()).optional().describe("Skillset hierarchy IDs. Use loxo_list_skillsets to discover IDs. E.g. [5704030] for Debt Advisory."),
+  sector_ids: z.array(z.number().int()).optional().describe("Sector hierarchy IDs. Use loxo_list_skillsets to discover IDs. E.g. [5690364] for Financial Services."),
+  person_type_id: z.number().int().optional().describe("Person type ID. 80073=Active Candidate, 78122=Prospect Candidate. Use loxo_list_person_types to discover."),
+  source_type_id: z.number().int().optional().describe("Source type ID. E.g. 1206583=LinkedIn, 1206592=API. Use loxo_list_source_types to discover."),
 });
 
 type PersonEventArgs = z.infer<typeof PersonEventSchema>;
@@ -947,20 +950,23 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "loxo_update_candidate",
-        description: "Update an existing candidate's record in Loxo. Use when a CV belongs to someone already in the system and you want to refresh their details. Provide only the fields you want to change — all parameters are optional except id.",
+        description: "Update an existing candidate's record in Loxo. Use to set tags, skillsets, sector, person type, source type, and basic profile fields. Tags and skillsets require specific field formats — this tool handles the conversion automatically. Use loxo_list_skillsets and loxo_list_person_types to discover valid IDs before calling.",
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
         inputSchema: {
           type: "object",
           properties: {
             id: { type: "string", description: "Candidate person ID (required)." },
             name: { type: "string", description: "Full name." },
-            email: { type: "string", description: "Primary email address." },
-            phone: { type: "string", description: "Primary phone number." },
+            email: { type: "string", description: "Email address to add." },
+            phone: { type: "string", description: "Phone number to add." },
             current_title: { type: "string", description: "Current job title." },
             current_company: { type: "string", description: "Current employer." },
             location: { type: "string", description: "City, region, or country." },
-            person_type_id: { type: "number", description: "Person type ID." },
-            tags: { type: "string", description: "Comma-separated tags." },
+            tags: { type: "array", items: { type: "string" }, description: "Tags to set. E.g. ['cv-import', 'debt-advisory']." },
+            skillset_ids: { type: "array", items: { type: "number" }, description: "Skillset IDs from loxo_list_skillsets. E.g. [5704030] = Debt Advisory." },
+            sector_ids: { type: "array", items: { type: "number" }, description: "Sector IDs from loxo_list_skillsets. E.g. [5690364] = Financial Services." },
+            person_type_id: { type: "number", description: "Person type ID. 80073=Active Candidate, 78122=Prospect Candidate." },
+            source_type_id: { type: "number", description: "Source type ID. 1206583=LinkedIn, 1206592=API." },
           },
           required: ["id"],
         },
@@ -1441,17 +1447,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "loxo_update_candidate": {
-        const { id, name: updateName, email, phone, current_title, current_company, location, person_type_id, tags } = UpdateCandidateSchema.parse(args);
+        const { id, name: updateName, email, phone, current_title, current_company, location, tags, skillset_ids, sector_ids, person_type_id, source_type_id } = UpdateCandidateSchema.parse(args);
 
         const formData = new URLSearchParams();
         if (updateName) formData.append('person[name]', updateName);
-        if (email) formData.append('person[email_addresses][][value]', email);
-        if (phone) formData.append('person[phone_numbers][][value]', phone);
+        if (email) formData.append('person[email]', email);
+        if (phone) formData.append('person[phone]', phone);
         if (current_title) formData.append('person[title]', current_title);
         if (current_company) formData.append('person[company]', current_company);
         if (location) formData.append('person[location]', location);
-        if (person_type_id) formData.append('person[person_type_ids][]', person_type_id.toString());
-        if (tags) formData.append('person[tag_list]', tags);
+        if (person_type_id) formData.append('person[person_type_id]', person_type_id.toString());
+        if (source_type_id) formData.append('person[source_type_id]', source_type_id.toString());
+        if (tags) {
+          for (const tag of tags) {
+            formData.append('person[all_raw_tags][]', tag);
+          }
+        }
+        if (skillset_ids) {
+          for (const sid of skillset_ids) {
+            formData.append('person[custom_hierarchy_1][]', sid.toString());
+          }
+        }
+        if (sector_ids) {
+          for (const sid of sector_ids) {
+            formData.append('person[custom_hierarchy_2][]', sid.toString());
+          }
+        }
 
         if (formData.toString() === '') {
           return {
@@ -1463,7 +1484,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const response = await makeRequest(
           `/${env.LOXO_AGENCY_SLUG}/people/${id}`,
           {
-            method: 'PATCH',
+            method: 'PUT',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: formData.toString(),
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -432,6 +432,12 @@ const AddToPipelineSchema = z.object({
   notes: z.string().optional().describe("Optional notes (e.g. 'Sourced from LinkedIn applications')."),
 });
 
+const UploadResumeSchema = z.object({
+  person_id: z.string().regex(/^\d+$/, "person_id must be numeric").describe("The candidate's person ID."),
+  file_name: z.string().describe("File name including extension (e.g. 'john-smith-cv.pdf')."),
+  file_content_base64: z.string().describe("Base64-encoded file content."),
+});
+
 type PersonEventArgs = z.infer<typeof PersonEventSchema>;
 type SearchArgs = z.infer<typeof SearchSchema>; // Generic search, might deprecate if specific ones cover all uses
 type TypeSearchCandidatesArgs = z.infer<typeof SearchCandidatesSchema>;
@@ -1035,6 +1041,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "loxo_upload_resume",
+        description: "Upload a CV/resume file to a candidate's Loxo profile. The file appears in the 'Resumes' section of their record. Accepts base64-encoded file content. Use after creating a candidate to attach their original CV. Example: Parse a CV, create the candidate with loxo_create_candidate, then upload the original file here.",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            person_id: { type: "string", description: "The candidate's person ID (required)." },
+            file_name: { type: "string", description: "File name with extension, e.g. 'john-smith-cv.pdf' (required)." },
+            file_content_base64: { type: "string", description: "Base64-encoded file content (required)." },
+          },
+          required: ["person_id", "file_name", "file_content_base64"],
+        },
+      },
+      {
         name: "loxo_list_person_types",
         description: "List all person type options (e.g. Active Candidate, Prospect Candidate). Use to discover valid person_type_id values before calling loxo_update_candidate.",
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
@@ -1632,6 +1652,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: formData.toString(),
+          }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
+        };
+      }
+
+      case "loxo_upload_resume": {
+        const { person_id, file_name, file_content_base64 } = UploadResumeSchema.parse(args);
+
+        const fileBuffer = Buffer.from(file_content_base64, 'base64');
+        const blob = new Blob([fileBuffer]);
+        const formData = new FormData();
+        formData.append('document', blob, file_name);
+
+        const response = await makeRequest(
+          `/${env.LOXO_AGENCY_SLUG}/people/${person_id}/resumes`,
+          {
+            method: 'POST',
+            body: formData,
+            // Do NOT set Content-Type — fetch sets it automatically with boundary for FormData
           }
         );
         return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1034,6 +1034,24 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["job_id", "person_id"],
         },
       },
+      {
+        name: "loxo_list_person_types",
+        description: "List all person type options (e.g. Active Candidate, Prospect Candidate). Use to discover valid person_type_id values before calling loxo_update_candidate.",
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+        inputSchema: { type: "object", properties: {}, required: [] },
+      },
+      {
+        name: "loxo_list_source_types",
+        description: "List all candidate source types (e.g. LinkedIn, API, Manual, Referral). Use to discover valid source_type_id values before calling loxo_create_candidate or loxo_update_candidate.",
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+        inputSchema: { type: "object", properties: {}, required: [] },
+      },
+      {
+        name: "loxo_list_skillsets",
+        description: "List all Skillset and Sector Experience hierarchy options with their IDs. Returns two sections: 'skillsets' (e.g. Debt Advisory, M&A/Lead Advisory, Transaction Services) and 'sectors' (e.g. TMT, Financial Services, Healthcare). Use the IDs with loxo_update_candidate's skillset_ids and sector_ids parameters.",
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+        inputSchema: { type: "object", properties: {}, required: [] },
+      },
     ]
   };
 });
@@ -1616,6 +1634,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             body: formData.toString(),
           }
         );
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
+        };
+      }
+
+      case "loxo_list_person_types": {
+        const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/person_types`);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
+        };
+      }
+
+      case "loxo_list_source_types": {
+        const response = await makeRequest(`/${env.LOXO_AGENCY_SLUG}/source_types`);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
+        };
+      }
+
+      case "loxo_list_skillsets": {
+        const [skillsetResult, sectorResult] = await Promise.all([
+          makeRequest<any>(`/${env.LOXO_AGENCY_SLUG}/dynamic_fields/2602521`),
+          makeRequest<any>(`/${env.LOXO_AGENCY_SLUG}/dynamic_fields/2602522`),
+        ]);
+
+        const response = {
+          skillsets: (skillsetResult?.hierarchies || []).map((h: any) => ({ id: h.id, name: h.name })),
+          sectors: (sectorResult?.hierarchies || []).map((h: any) => ({ id: h.id, name: h.name })),
+        };
         return {
           content: [{ type: "text", text: JSON.stringify(response, null, 2) }]
         };

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -384,4 +384,41 @@ describe('Loxo MCP tool handlers', () => {
       expect(result.content[0].text).toContain('TMT');
     });
   });
+
+  // ─── loxo_upload_resume ─────────────────────────────────────────────────
+
+  describe('loxo_upload_resume', () => {
+    it('uploads resume to /people/{id}/resumes endpoint', async () => {
+      let capturedUrl = '';
+      let capturedBody: any = null;
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, opts: any) => {
+        capturedUrl = url;
+        capturedBody = opts?.body;
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({
+            id: 12345, name: 'cv.pdf', person_id: 42, created_at: '2026-03-16T12:00:00Z'
+          })),
+        });
+      }));
+      const result = await callTool(client, 'loxo_upload_resume', {
+        person_id: '42',
+        file_name: 'cv.pdf',
+        file_content_base64: Buffer.from('fake pdf content').toString('base64'),
+      });
+      expect(result.isError).toBeFalsy();
+      expect(capturedUrl).toContain('/people/42/resumes');
+      // Body should be FormData (not URLSearchParams)
+      expect(capturedBody).toBeInstanceOf(FormData);
+      expect(result.content[0].text).toContain('cv.pdf');
+    });
+
+    it('returns error when person_id is missing', async () => {
+      const result = await callTool(client, 'loxo_upload_resume', {
+        file_name: 'cv.pdf',
+        file_content_base64: Buffer.from('content').toString('base64'),
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
 });

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -223,19 +223,38 @@ describe('Loxo MCP tool handlers', () => {
   // ─── loxo_update_candidate ────────────────────────────────────────────────
 
   describe('loxo_update_candidate', () => {
-    it('updates candidate and returns updated record', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: () => Promise.resolve(JSON.stringify({ id: '42', name: 'Jane Smith', title: 'Senior Engineer' })),
+    it('sends PUT with person[all_raw_tags][] array and person[custom_hierarchy_1][]', async () => {
+      let capturedMethod = '';
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedMethod = opts?.method || 'GET';
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({
+            person: { id: 42, name: 'Jane Smith', all_raw_tags: 'debt-advisory, sourced', custom_hierarchy_1: [{ id: 5704030, value: 'Debt Advisory' }] }
+          })),
+        });
       }));
       const result = await callTool(client, 'loxo_update_candidate', {
         id: '42',
-        current_title: 'Senior Engineer',
+        current_title: 'Senior Analyst',
+        tags: ['debt-advisory', 'sourced'],
+        skillset_ids: [5704030],
+        person_type_id: 80073,
+        source_type_id: 1206583,
       });
       expect(result.isError).toBeFalsy();
-      expect(result.content[0].text).toContain('Senior Engineer');
+      expect(capturedMethod).toBe('PUT');
+      // Tags must use array notation person[all_raw_tags][]=x
+      expect(capturedBody).toContain('person%5Ball_raw_tags%5D%5B%5D=debt-advisory');
+      expect(capturedBody).toContain('person%5Ball_raw_tags%5D%5B%5D=sourced');
+      // Skillsets use custom_hierarchy_1
+      expect(capturedBody).toContain('person%5Bcustom_hierarchy_1%5D%5B%5D=5704030');
+      // Person type uses singular form
+      expect(capturedBody).toContain('person%5Bperson_type_id%5D=80073');
+      // Source type
+      expect(capturedBody).toContain('person%5Bsource_type_id%5D=1206583');
     });
 
     it('returns error when only id is provided (empty body guard)', async () => {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -325,4 +325,63 @@ describe('Loxo MCP tool handlers', () => {
       expect(result.content[0].text).toContain('Test call logged');
     });
   });
+
+  // ─── loxo_list_person_types ─────────────────────────────────────────────
+
+  describe('loxo_list_person_types', () => {
+    it('returns person types list', async () => {
+      mockFetch([
+        { id: 80073, name: 'Active Candidate' },
+        { id: 78122, name: 'Prospect Candidate' },
+      ]);
+      const result = await callTool(client, 'loxo_list_person_types', {});
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Active Candidate');
+      expect(result.content[0].text).toContain('Prospect Candidate');
+    });
+  });
+
+  // ─── loxo_list_source_types ─────────────────────────────────────────────
+
+  describe('loxo_list_source_types', () => {
+    it('returns source types list', async () => {
+      mockFetch({ source_types: [
+        { id: 1206583, name: 'LinkedIn', active: true },
+        { id: 1206592, name: 'API', active: true },
+      ]});
+      const result = await callTool(client, 'loxo_list_source_types', {});
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('LinkedIn');
+      expect(result.content[0].text).toContain('API');
+    });
+  });
+
+  // ─── loxo_list_skillsets ────────────────────────────────────────────────
+
+  describe('loxo_list_skillsets', () => {
+    it('returns skillset and sector hierarchies', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+        let data: unknown;
+        if (url.includes('2602521')) {
+          data = { id: 2602521, name: 'Skillset', hierarchies: [
+            { id: 5704030, name: 'Debt Advisory', hierarchies: [] },
+            { id: 5690346, name: 'M&A/Lead Advisory', hierarchies: [] },
+          ]};
+        } else {
+          data = { id: 2602522, name: 'Sector Experience', hierarchies: [
+            { id: 5690362, name: 'TMT', hierarchies: [] },
+            { id: 5690364, name: 'Financial Services', hierarchies: [] },
+          ]};
+        }
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify(data)),
+        });
+      }));
+      const result = await callTool(client, 'loxo_list_skillsets', {});
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Debt Advisory');
+      expect(result.content[0].text).toContain('TMT');
+    });
+  });
 });

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -266,30 +266,42 @@ describe('Loxo MCP tool handlers', () => {
 
   // ─── loxo_apply_to_job ────────────────────────────────────────────────────
 
-  describe('loxo_apply_to_job', () => {
-    it('adds candidate to job pipeline', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: () => Promise.resolve(JSON.stringify({ id: 1, person_id: '42', job_id: '100' })),
+  describe('loxo_add_to_pipeline', () => {
+    it('creates person_event with activity_type_id 1550055 (Added to Job)', async () => {
+      let capturedUrl = '';
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string, opts: any) => {
+        capturedUrl = url;
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({
+            person_event: { id: 123, person_id: 42, job_id: 100, activity_type_id: 1550055, notes: 'Sourced from CV search' }
+          })),
+        });
       }));
-      const result = await callTool(client, 'loxo_apply_to_job', {
+      const result = await callTool(client, 'loxo_add_to_pipeline', {
         job_id: '100',
         person_id: '42',
+        notes: 'Sourced from CV search',
       });
       expect(result.isError).toBeFalsy();
-      expect(result.content[0].text).toContain('"person_id": "42"');
+      // Must hit person_events endpoint, NOT jobs/{id}/contacts
+      expect(capturedUrl).toContain('/person_events');
+      expect(capturedUrl).not.toContain('/contacts');
+      // Must include the "Added to Job" activity type
+      expect(capturedBody).toContain('person_event%5Bactivity_type_id%5D=1550055');
+      expect(capturedBody).toContain('person_event%5Bjob_id%5D=100');
+      expect(capturedBody).toContain('person_event%5Bperson_id%5D=42');
     });
 
     it('returns error when job_id is missing', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-        ok: false,
-        status: 400,
-        statusText: 'Bad Request',
-        text: () => Promise.resolve(JSON.stringify({ error: 'job_id is required' })),
-      }));
-      const result = await callTool(client, 'loxo_apply_to_job', { person_id: '42' });
+      const result = await callTool(client, 'loxo_add_to_pipeline', { person_id: '42' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns error when person_id is missing', async () => {
+      const result = await callTool(client, 'loxo_add_to_pipeline', { job_id: '100' });
       expect(result.isError).toBe(true);
     });
   });

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -185,21 +185,31 @@ describe('Loxo MCP tool handlers', () => {
   // ─── loxo_create_candidate ────────────────────────────────────────────────
 
   describe('loxo_create_candidate', () => {
-    it('creates candidate and returns the new record', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: () => Promise.resolve(JSON.stringify({ id: '99', name: 'TEST - Jane Doe', title: 'Engineer' })),
+    it('sends person[email] and person[phone] (not bracket-array notation)', async () => {
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({
+            person: { id: 99, name: 'TEST - Jane Doe', emails: [{ value: 'jane@test.com' }], phones: [{ value: '447700900000' }] }
+          })),
+        });
       }));
       const result = await callTool(client, 'loxo_create_candidate', {
         name: 'TEST - Jane Doe',
-        email: 'test-jane@example.com',
-        current_title: 'Engineer',
-        tags: 'test-record,ci-test',
+        email: 'jane@test.com',
+        phone: '+447700900000',
+        current_title: 'Analyst',
+        current_company: 'Test Corp',
       });
       expect(result.isError).toBeFalsy();
-      expect(result.content[0].text).toContain('TEST - Jane Doe');
+      // Must use simple field names, NOT email_addresses[][value]
+      expect(capturedBody).toContain('person%5Bemail%5D=');     // person[email]
+      expect(capturedBody).toContain('person%5Bphone%5D=');     // person[phone]
+      expect(capturedBody).not.toContain('email_addresses');
+      expect(capturedBody).not.toContain('phone_numbers');
+      expect(capturedBody).not.toContain('source_type_id');
     });
 
     it('returns error when required name is missing', async () => {


### PR DESCRIPTION
## Summary

Fixes 3 broken tools and adds 4 new ones based on live API probing, so Claude can run a full recruiter workflow end-to-end without manual Loxo UI intervention.

**Context:** During a client cowork session (Axis Arbor Analyst shortlisting), `loxo_create_candidate` rejected email/phone fields, `loxo_apply_to_job` added company contacts instead of pipeline candidates, and several needed capabilities were missing entirely.

### Fixes
- **`loxo_create_candidate`** — use `person[email]`/`person[phone]` (simple fields) instead of broken `email_addresses[][value]` bracket-array notation. Remove tags/person_type_id from create (must be set via follow-up PUT)
- **`loxo_update_candidate`** — switch from PATCH to PUT. Add tags (`person[all_raw_tags][]`), skillsets (`person[custom_hierarchy_1][]`), sectors (`person[custom_hierarchy_2][]`), `person_type_id` (singular), `source_type_id`
- **`loxo_apply_to_job` → `loxo_add_to_pipeline`** — the old endpoint (`POST /jobs/{id}/contacts`) added company contacts (hiring manager, billing), NOT pipeline candidates. New implementation uses `POST /person_events` with `activity_type_id=1550055` ("Added to Job"), which is how Loxo internally manages pipelines

### New tools
- **`loxo_upload_resume`** — multipart CV upload to `POST /people/{id}/resumes`
- **`loxo_list_person_types`** — discover Active Candidate, Prospect Candidate, etc.
- **`loxo_list_source_types`** — discover LinkedIn, API, Manual, Referral, etc.
- **`loxo_list_skillsets`** — discover Skillset hierarchy (Debt Advisory, M&A, etc.) and Sector hierarchy (TMT, Financial Services, etc.)

### Breaking change
`loxo_apply_to_job` renamed to `loxo_add_to_pipeline`. The old tool was fundamentally broken (never actually added candidates to pipelines), so this is a necessary break.

## Test plan
- [x] All 30 tests pass (up from 24)
- [x] Lint: 0 errors (52 pre-existing `no-explicit-any` warnings)
- [x] Build: clean TypeScript compile
- [ ] After merge: tag `v1.4.0` and push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)