### PR TITLE
fix: raise CHARACTER_LIMIT from 25k to 100k

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ const env = validateEnv();
 const LOXO_API_BASE = `https://${env.LOXO_DOMAIN}/api`;
 
 // MCP Best Practice: Character limit for responses to prevent overwhelming context
-const CHARACTER_LIMIT = 25000;
+const CHARACTER_LIMIT = 100000;
 
 // Helper function to truncate responses with clear messaging
 function truncateResponse(content: string, limit: number = CHARACTER_LIMIT): { text: string; wasTruncated: boolean } {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -10,11 +10,11 @@ describe('truncateResponse', () => {
   });
 
   it('truncates text that exceeds the limit', () => {
-    const longText = 'a'.repeat(30000);
+    const longText = 'a'.repeat(150000);
     const result = truncateResponse(longText);
     expect(result.wasTruncated).toBe(true);
     expect(result.text).toContain('[Response truncated');
-    expect(result.text.length).toBeLessThan(30000);
+    expect(result.text.length).toBeLessThan(150000);
   });
 
   it('respects a custom limit', () => {


### PR DESCRIPTION
## Summary

- Raise `CHARACTER_LIMIT` from 25,000 to 100,000 characters
- Fixes truncated responses causing Claude to miss jobs and pipeline candidates

**Root cause:** 25k was too aggressive for real-world data. A pipeline with 15 candidates or a search returning full profiles easily exceeds 25k characters.

## Test plan
- [x] All 60 tests pass
- [x] Updated truncation test to use values above the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)