### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loxo-mcp-server",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Version bump to 1.4.1 (includes CHARACTER_LIMIT fix from #15)
- Tag `v1.4.1` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)