### PR TITLE
fix: add base path for docs site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'Loxo MCP Server',
   description: 'Give Claude direct access to your Loxo recruitment platform',
+  base: '/loxo-mcp-server/',
 
   srcExclude: ['plans/**', 'superpowers/**'],
 


### PR DESCRIPTION
## Summary

- Adds `base: '/loxo-mcp-server/'` to VitePress config
- GitHub Pages serves the site at `/loxo-mcp-server/`, not the domain root
- Without this, all CSS, JS, and font assets 404 because they load from `/assets/` instead of `/loxo-mcp-server/assets/`

## Test plan

- [x] `npm run docs:build` passes
- [ ] After merge, verify site renders with styles at https://tbensonwest.github.io/loxo-mcp-server/

🤖 Generated with [Claude Code](https://claude.com/claude-code)