### PR TITLE
Make response size limit configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loxo-mcp-server",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "type": "module",
   "main": "build/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,11 +20,7 @@ const envSchema = z.object({
     )
     .optional(),
   LOXO_DEFAULT_OWNER_EMAIL: z.string().optional(),
-  LOXO_MCP_RESPONSE_LIMIT: z
-    .string()
-    .regex(/^\d+$/, 'LOXO_MCP_RESPONSE_LIMIT must be a number')
-    .transform(Number)
-    .default('250000'),
+  LOXO_MCP_RESPONSE_LIMIT: z.coerce.number().int().positive().default(250000),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,11 @@ const envSchema = z.object({
     )
     .optional(),
   LOXO_DEFAULT_OWNER_EMAIL: z.string().optional(),
+  LOXO_MCP_RESPONSE_LIMIT: z
+    .string()
+    .regex(/^\d+$/, 'LOXO_MCP_RESPONSE_LIMIT must be a number')
+    .transform(Number)
+    .default('250000'),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,8 +12,8 @@ const env = validateEnv();
 // Construct API base URL using domain from config
 const LOXO_API_BASE = `https://${env.LOXO_DOMAIN}/api`;
 
-// MCP Best Practice: Character limit for responses to prevent overwhelming context
-const CHARACTER_LIMIT = 100000;
+// Configurable response size limit (default 250K, override via LOXO_MCP_RESPONSE_LIMIT env var)
+const CHARACTER_LIMIT = env.LOXO_MCP_RESPONSE_LIMIT;
 
 // Helper function to truncate responses with clear messaging
 function truncateResponse(content: string, limit: number = CHARACTER_LIMIT): { text: string; wasTruncated: boolean } {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -10,11 +10,11 @@ describe('truncateResponse', () => {
   });
 
   it('truncates text that exceeds the limit', () => {
-    const longText = 'a'.repeat(150000);
+    const longText = 'a'.repeat(300000);
     const result = truncateResponse(longText);
     expect(result.wasTruncated).toBe(true);
     expect(result.text).toContain('[Response truncated');
-    expect(result.text.length).toBeLessThan(150000);
+    expect(result.text.length).toBeLessThan(300000);
   });
 
   it('respects a custom limit', () => {


### PR DESCRIPTION
## Summary
- Adds `LOXO_MCP_RESPONSE_LIMIT` env var to control max response character length
- Default raised from 100K to 250K
- Prevents mid-JSON truncation that caused parse failures in n8n workflow consumers

## Context
The hard-coded 100K limit was truncating `loxo_get_candidate_brief` responses for ~15% of candidates with large profiles (rich activity history, multiple job profiles, detailed recruiter notes). The truncation cut JSON mid-structure and appended a text message, making the response unparseable.

## Test plan
- [x] All 112 existing tests pass
- [ ] Deploy and verify enrichment rate improves from 87/101 to ~100/101

🤖 Generated with [Claude Code](https://claude.com/claude-code)