### PR TITLE
fix(update_candidate): tags additive by default, add compensation + extra_fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "loxo-mcp-server",
-  "version": "1.6.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loxo-mcp-server",
-      "version": "1.6.0",
+      "version": "1.7.1",
+      "license": "MIT",
       "dependencies": {
         "@api/loxo": "file:.api/apis/loxo",
         "@modelcontextprotocol/sdk": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loxo-mcp-server",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loxo-mcp-server",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@api/loxo": "file:.api/apis/loxo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loxo-mcp-server",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "license": "MIT",
   "type": "module",
   "main": "build/index.js",

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  var LOXO_PERSON_KEY_CACHE: Set<string> | undefined;
+}
+
+export {};

--- a/src/server.ts
+++ b/src/server.ts
@@ -468,6 +468,12 @@ const UpdateCandidateSchema = z.object({
   salary_type_id: z.number().optional().describe("Salary type ID (e.g. annual, hourly). Use loxo_list_salary_types to discover IDs."),
   bonus: z.number().optional().describe("Bonus amount, numeric."),
   description: z.string().optional().describe("The bio / recruiter notes blob. Free text. Replaces existing description."),
+  extra_fields: z.record(
+    z.string(),
+    z.union([z.string(), z.number(), z.array(z.union([z.string(), z.number()]))])
+  ).optional().describe(
+    "Map of {loxo_key: value} for any top-level person field not already covered by an explicit parameter (built-in or tenant-specific dynamic fields, all addressable via person[<key>]). Keys are validated against the dynamic_fields schema cached at server startup; with a cache miss they fall back to /^[a-zA-Z][a-zA-Z0-9_]*$/. Values may be string, number, or an array of strings/numbers (used for Hierarchy fields like skillset_ids that Loxo writes as person[<key>][] form entries, per Phase 0.3 verification)."
+  ),
 });
 
 const AddToPipelineSchema = z.object({
@@ -1123,6 +1129,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             salary_type_id: { type: "number", description: "Salary type ID (e.g. annual, hourly). Use loxo_list_salary_types to discover IDs." },
             bonus: { type: "number", description: "Bonus amount, numeric." },
             description: { type: "string", description: "The bio / recruiter notes blob. Free text. Replaces existing description." },
+            extra_fields: {
+              type: "object",
+              description: "Map of Loxo person field keys (top-level on the person object) to values. Use to set fields not covered by explicit parameters. E.g. { \"expected_salary\": 95000, \"rejection_reason\": \"comp expectations\", \"skillset_ids\": [12, 34] }. Arrays are written as person[<key>][] form entries (used for Hierarchy fields like skillsets and sectors).",
+              additionalProperties: {
+                oneOf: [
+                  { type: "string" },
+                  { type: "number" },
+                  { type: "array", items: { type: ["string", "number"] } }
+                ]
+              }
+            },
           },
           required: ["id"],
         },
@@ -1801,7 +1818,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "loxo_update_candidate": {
-        const { id, name: updateName, email, phone, current_title, current_company, location, tags, replace_tags, skillset_ids, sector_ids, person_type_id, source_type_id, owned_by_id, salary, compensation, compensation_currency_id, salary_type_id, bonus, description } = UpdateCandidateSchema.parse(args);
+        const { id, name: updateName, email, phone, current_title, current_company, location, tags, replace_tags, skillset_ids, sector_ids, person_type_id, source_type_id, owned_by_id, salary, compensation, compensation_currency_id, salary_type_id, bonus, description, extra_fields } = UpdateCandidateSchema.parse(args);
 
         const formData = new URLSearchParams();
         if (updateName) formData.append('person[name]', updateName);
@@ -1835,6 +1852,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (salary_type_id !== undefined) formData.append('person[salary_type_id]', salary_type_id.toString());
         if (bonus !== undefined) formData.append('person[bonus]', bonus.toString());
         if (description !== undefined) formData.append('person[description]', description);
+
+        if (extra_fields) {
+          const SAFE_KEY = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+          // Optional schema-cache check. If the server has loaded /dynamic_fields at
+          // startup, prefer membership in the cached Person key set; otherwise fall
+          // back to the regex. Built-in keys (salary, compensation, etc.) appear in
+          // /dynamic_fields with built_in: true so the cache covers both kinds.
+          const personKeyCache: Set<string> | null = (globalThis as any).LOXO_PERSON_KEY_CACHE ?? null;
+          for (const [key, value] of Object.entries(extra_fields)) {
+            const allowed = personKeyCache ? personKeyCache.has(key) : SAFE_KEY.test(key);
+            if (!allowed) {
+              return {
+                content: [{ type: "text", text: `Invalid extra_fields key: ${key}. Not in cached Person dynamic_fields schema and does not match safe-key pattern.` }],
+                isError: true,
+              };
+            }
+            if (Array.isArray(value)) {
+              // Hierarchy fields (skillset_ids, sector_ids, custom_hierarchy_*) come
+              // back from Loxo as arrays per Phase 0.3 verification, so they must be
+              // written via person[<key>][] form entries (one append per element).
+              // value.toString() on an array would join with commas, which Loxo treats
+              // as a single string and silently drops.
+              for (const v of value) formData.append(`person[${key}][]`, v.toString());
+            } else {
+              formData.append(`person[${key}]`, value.toString());
+            }
+          }
+        }
 
         const resolvedOwnerId = resolveOwnerId(owned_by_id);
         if (resolvedOwnerId) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -459,6 +459,9 @@ const UpdateCandidateSchema = z.object({
   person_type_id: z.number().int().optional().describe("Person type ID. 80073=Active Candidate, 78122=Prospect Candidate. Use loxo_list_person_types to discover."),
   source_type_id: z.number().int().optional().describe("Source type ID. E.g. 1206583=LinkedIn, 1206592=API. Use loxo_list_source_types to discover."),
   owned_by_id: z.coerce.string().regex(/^\d+$/, "owned_by_id must be numeric").optional().describe("Loxo user ID to set as record owner. Overrides LOXO_DEFAULT_OWNER_ID env var."),
+  replace_tags: z.boolean().optional().default(false).describe(
+    "When true, REPLACES existing tags with the provided array (uses person[all_raw_tags][]). When false (default), adds the provided tags additively (uses person[raw_tags][]) and leaves existing tags untouched."
+  ),
 });
 
 const AddToPipelineSchema = z.object({
@@ -1101,7 +1104,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             current_title: { type: "string", description: "Current job title." },
             current_company: { type: "string", description: "Current employer." },
             location: { type: "string", description: "City, region, or country." },
-            tags: { type: "array", items: { type: "string" }, description: "Tags to set. E.g. ['cv-import', 'debt-advisory']." },
+            tags: { type: "array", items: { type: "string" }, description: "Tags to add (additive by default, does not remove existing). Use replace_tags=true to set the full list explicitly. E.g. ['cv-import', 'debt-advisory']." },
+            replace_tags: { type: "boolean", description: "Default false (additive). Set to true to REPLACE existing tags with the provided array. Use with care: replace mode wipes any tags not in the input." },
             skillset_ids: { type: "array", items: { type: "number" }, description: "Skillset IDs from loxo_list_skillsets. E.g. [5704030] = Debt Advisory." },
             sector_ids: { type: "array", items: { type: "number" }, description: "Sector IDs from loxo_list_skillsets. E.g. [5690364] = Financial Services." },
             person_type_id: { type: "number", description: "Person type ID. 80073=Active Candidate, 78122=Prospect Candidate." },
@@ -1785,7 +1789,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "loxo_update_candidate": {
-        const { id, name: updateName, email, phone, current_title, current_company, location, tags, skillset_ids, sector_ids, person_type_id, source_type_id, owned_by_id } = UpdateCandidateSchema.parse(args);
+        const { id, name: updateName, email, phone, current_title, current_company, location, tags, replace_tags, skillset_ids, sector_ids, person_type_id, source_type_id, owned_by_id } = UpdateCandidateSchema.parse(args);
 
         const formData = new URLSearchParams();
         if (updateName) formData.append('person[name]', updateName);
@@ -1797,8 +1801,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (person_type_id) formData.append('person[person_type_id]', person_type_id.toString());
         if (source_type_id) formData.append('person[source_type_id]', source_type_id.toString());
         if (tags) {
+          const fieldName = replace_tags ? 'person[all_raw_tags][]' : 'person[raw_tags][]';
           for (const tag of tags) {
-            formData.append('person[all_raw_tags][]', tag);
+            formData.append(fieldName, tag);
           }
         }
         if (skillset_ids) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1859,7 +1859,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           // startup, prefer membership in the cached Person key set; otherwise fall
           // back to the regex. Built-in keys (salary, compensation, etc.) appear in
           // /dynamic_fields with built_in: true so the cache covers both kinds.
-          const personKeyCache: Set<string> | null = (globalThis as any).LOXO_PERSON_KEY_CACHE ?? null;
+          const personKeyCache: Set<string> | null = globalThis.LOXO_PERSON_KEY_CACHE ?? null;
           for (const [key, value] of Object.entries(extra_fields)) {
             const allowed = personKeyCache ? personKeyCache.has(key) : SAFE_KEY.test(key);
             if (!allowed) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -462,6 +462,12 @@ const UpdateCandidateSchema = z.object({
   replace_tags: z.boolean().optional().default(false).describe(
     "When true, REPLACES existing tags with the provided array (uses person[all_raw_tags][]). When false (default), adds the provided tags additively (uses person[raw_tags][]) and leaves existing tags untouched."
   ),
+  salary: z.number().optional().describe("Current salary, numeric (no currency symbol). Pair with compensation_currency_id."),
+  compensation: z.number().optional().describe("Total compensation including base + bonus + equity, numeric."),
+  compensation_currency_id: z.number().optional().describe("Currency ID. Use loxo_list_currencies to discover IDs."),
+  salary_type_id: z.number().optional().describe("Salary type ID (e.g. annual, hourly). Use loxo_list_salary_types to discover IDs."),
+  bonus: z.number().optional().describe("Bonus amount, numeric."),
+  description: z.string().optional().describe("The bio / recruiter notes blob. Free text. Replaces existing description."),
 });
 
 const AddToPipelineSchema = z.object({
@@ -1111,6 +1117,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             person_type_id: { type: "number", description: "Person type ID. 80073=Active Candidate, 78122=Prospect Candidate." },
             source_type_id: { type: "number", description: "Source type ID. 1206583=LinkedIn, 1206592=API." },
             owned_by_id: { type: "string", description: "Loxo user ID to set as record owner. Overrides LOXO_DEFAULT_OWNER_ID env var." },
+            salary: { type: "number", description: "Current salary, numeric (no currency symbol). Pair with compensation_currency_id." },
+            compensation: { type: "number", description: "Total compensation including base + bonus + equity, numeric." },
+            compensation_currency_id: { type: "number", description: "Currency ID. Use loxo_list_currencies to discover IDs." },
+            salary_type_id: { type: "number", description: "Salary type ID (e.g. annual, hourly). Use loxo_list_salary_types to discover IDs." },
+            bonus: { type: "number", description: "Bonus amount, numeric." },
+            description: { type: "string", description: "The bio / recruiter notes blob. Free text. Replaces existing description." },
           },
           required: ["id"],
         },
@@ -1789,7 +1801,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "loxo_update_candidate": {
-        const { id, name: updateName, email, phone, current_title, current_company, location, tags, replace_tags, skillset_ids, sector_ids, person_type_id, source_type_id, owned_by_id } = UpdateCandidateSchema.parse(args);
+        const { id, name: updateName, email, phone, current_title, current_company, location, tags, replace_tags, skillset_ids, sector_ids, person_type_id, source_type_id, owned_by_id, salary, compensation, compensation_currency_id, salary_type_id, bonus, description } = UpdateCandidateSchema.parse(args);
 
         const formData = new URLSearchParams();
         if (updateName) formData.append('person[name]', updateName);
@@ -1816,6 +1828,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             formData.append('person[custom_hierarchy_2][]', sid.toString());
           }
         }
+
+        if (salary !== undefined) formData.append('person[salary]', salary.toString());
+        if (compensation !== undefined) formData.append('person[compensation]', compensation.toString());
+        if (compensation_currency_id !== undefined) formData.append('person[compensation_currency_id]', compensation_currency_id.toString());
+        if (salary_type_id !== undefined) formData.append('person[salary_type_id]', salary_type_id.toString());
+        if (bonus !== undefined) formData.append('person[bonus]', bonus.toString());
+        if (description !== undefined) formData.append('person[description]', description);
 
         const resolvedOwnerId = resolveOwnerId(owned_by_id);
         if (resolvedOwnerId) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,10 @@ const LOXO_API_BASE = `https://${env.LOXO_DOMAIN}/api`;
 // Configurable response size limit (default 250K, override via LOXO_MCP_RESPONSE_LIMIT env var)
 const CHARACTER_LIMIT = env.LOXO_MCP_RESPONSE_LIMIT;
 
+// Fallback key validator for loxo_update_candidate's extra_fields, used when
+// the LOXO_PERSON_KEY_CACHE global is absent (e.g. offline tests).
+const SAFE_PERSON_FIELD_KEY = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+
 // Helper function to truncate responses with clear messaging
 function truncateResponse(content: string, limit: number = CHARACTER_LIMIT): { text: string; wasTruncated: boolean } {
   if (content.length <= limit) {
@@ -1854,14 +1858,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (description !== undefined) formData.append('person[description]', description);
 
         if (extra_fields) {
-          const SAFE_KEY = /^[a-zA-Z][a-zA-Z0-9_]*$/;
           // Optional schema-cache check. If the server has loaded /dynamic_fields at
           // startup, prefer membership in the cached Person key set; otherwise fall
-          // back to the regex. Built-in keys (salary, compensation, etc.) appear in
-          // /dynamic_fields with built_in: true so the cache covers both kinds.
+          // back to the SAFE_PERSON_FIELD_KEY regex. Built-in keys (salary,
+          // compensation, etc.) appear in /dynamic_fields with built_in: true so
+          // the cache covers both kinds.
           const personKeyCache: Set<string> | null = globalThis.LOXO_PERSON_KEY_CACHE ?? null;
           for (const [key, value] of Object.entries(extra_fields)) {
-            const allowed = personKeyCache ? personKeyCache.has(key) : SAFE_KEY.test(key);
+            const allowed = personKeyCache ? personKeyCache.has(key) : SAFE_PERSON_FIELD_KEY.test(key);
             if (!allowed) {
               return {
                 content: [{ type: "text", text: `Invalid extra_fields key: ${key}. Not in cached Person dynamic_fields schema and does not match safe-key pattern.` }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -1104,8 +1104,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "loxo_update_candidate",
-        description: "Update an existing candidate's record in Loxo. Use to set tags, skillsets, sector, person type, source type, and basic profile fields. Tags and skillsets require specific field formats — this tool handles the conversion automatically. Use loxo_list_skillsets and loxo_list_person_types to discover valid IDs before calling. Ownership can be set via owned_by_id (falls back to LOXO_DEFAULT_OWNER_ID env var).",
-        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+        description: "Update an existing candidate's record in Loxo. Use to set tags, skillsets, sector, person type, source type, basic profile fields, compensation (salary, bonus, currency, salary_type), the description blob, and any other top-level person field via extra_fields. Tags are additive by default (does not remove existing); pass replace_tags=true for the destructive replace behaviour. Tags and skillsets require specific field formats: this tool handles the conversion automatically. Use loxo_list_skillsets and loxo_list_person_types to discover IDs. Use the dynamic_fields discovery probe to enumerate the valid extra_fields keys for the tenant.",
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
         inputSchema: {
           type: "object",
           properties: {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -769,6 +769,65 @@ describe('Loxo MCP tool handlers', () => {
       expect(capturedBody).toContain('person%5Bbonus%5D=15000');
       expect(capturedBody).toContain('person%5Bdescription%5D=Strong+candidate');
     });
+
+    it('sends PUT with person[<key>] entries when extra_fields map is provided', async () => {
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({ person: { id: 42 } })),
+        });
+      }));
+
+      await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        extra_fields: {
+          expected_salary: 95000,
+          rejection_reason: 'comp expectations too high',
+        },
+      });
+
+      // Plain person[<key>], no $-prefix, per Phase 0.3 verification.
+      expect(capturedBody).toContain('person%5Bexpected_salary%5D=95000');
+      expect(capturedBody).toContain('person%5Brejection_reason%5D=comp+expectations+too+high');
+    });
+
+    it('rejects extra_fields keys that contain unsafe characters', async () => {
+      const result = await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        extra_fields: {
+          'bad key with spaces': 'value',
+        },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('writes array extra_fields values as person[<key>][] form entries', async () => {
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({ person: { id: 42 } })),
+        });
+      }));
+
+      // Hierarchy fields (skillset_ids, sector_ids, custom_hierarchy_*) come back
+      // from Loxo as arrays per Phase 0.3 verification, and must be written via
+      // person[<key>][] entries (one per element), not joined into a string.
+      await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        extra_fields: {
+          skillset_ids: [12, 34],
+        },
+      });
+
+      expect(capturedBody).toContain('person%5Bskillset_ids%5D%5B%5D=12');
+      expect(capturedBody).toContain('person%5Bskillset_ids%5D%5B%5D=34');
+      // Crucially, NOT a comma-joined single value:
+      expect(capturedBody).not.toContain('person%5Bskillset_ids%5D=12%2C34');
+    });
   });
 
   // ─── loxo_apply_to_job ────────────────────────────────────────────────────

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -741,6 +741,34 @@ describe('Loxo MCP tool handlers', () => {
       expect(result.isError).toBeFalsy();
       expect(capturedBody).not.toContain('owned_by_id');
     });
+
+    it('sends PUT with compensation fields when provided', async () => {
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({ person: { id: 42 } })),
+        });
+      }));
+
+      await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        salary: 95000,
+        compensation: 110000,
+        compensation_currency_id: 1,
+        salary_type_id: 2,
+        bonus: 15000,
+        description: 'Strong candidate from referral, looking to move within 3 months.',
+      });
+
+      expect(capturedBody).toContain('person%5Bsalary%5D=95000');
+      expect(capturedBody).toContain('person%5Bcompensation%5D=110000');
+      expect(capturedBody).toContain('person%5Bcompensation_currency_id%5D=1');
+      expect(capturedBody).toContain('person%5Bsalary_type_id%5D=2');
+      expect(capturedBody).toContain('person%5Bbonus%5D=15000');
+      expect(capturedBody).toContain('person%5Bdescription%5D=Strong+candidate');
+    });
   });
 
   // ─── loxo_apply_to_job ────────────────────────────────────────────────────

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -828,6 +828,45 @@ describe('Loxo MCP tool handlers', () => {
       // Crucially, NOT a comma-joined single value:
       expect(capturedBody).not.toContain('person%5Bskillset_ids%5D=12%2C34');
     });
+
+    it('allows extra_fields keys present in LOXO_PERSON_KEY_CACHE even when they would fail the safe-key regex', async () => {
+      // When the cache is populated (loaded by a future PR from /dynamic_fields),
+      // it is the source of truth and trumps the SAFE_KEY regex fallback.
+      vi.stubGlobal('LOXO_PERSON_KEY_CACHE', new Set(['custom_hierarchy_1', 'fee-percentage']));
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({ person: { id: 42 } })),
+        });
+      }));
+
+      // 'fee-percentage' fails the SAFE_KEY regex (hyphens not allowed) but is in
+      // the cache, so the handler should accept and forward it.
+      const result = await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        extra_fields: { 'fee-percentage': 25 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedBody).toContain('person%5Bfee-percentage%5D=25');
+    });
+
+    it('rejects extra_fields keys not present in LOXO_PERSON_KEY_CACHE (strict allowlist when cache is loaded)', async () => {
+      // Inverse of the test above: when the cache is populated, the regex
+      // fallback is bypassed, so a regex-safe key that is not in the cache
+      // is still rejected. This guards against typoed keys reaching Loxo.
+      vi.stubGlobal('LOXO_PERSON_KEY_CACHE', new Set(['expected_salary']));
+
+      const result = await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        // 'unknown_field' matches the SAFE_KEY regex but is not in the cache.
+        extra_fields: { unknown_field: 'value' },
+      });
+
+      expect(result.isError).toBe(true);
+    });
   });
 
   // ─── loxo_apply_to_job ────────────────────────────────────────────────────

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -572,13 +572,14 @@ describe('Loxo MCP tool handlers', () => {
         id: '42',
         current_title: 'Senior Analyst',
         tags: ['debt-advisory', 'sourced'],
+        replace_tags: true,
         skillset_ids: [5704030],
         person_type_id: 80073,
         source_type_id: 1206583,
       });
       expect(result.isError).toBeFalsy();
       expect(capturedMethod).toBe('PUT');
-      // Tags must use array notation person[all_raw_tags][]=x
+      // Tags must use array notation person[all_raw_tags][]=x when replace_tags=true
       expect(capturedBody).toContain('person%5Ball_raw_tags%5D%5B%5D=debt-advisory');
       expect(capturedBody).toContain('person%5Ball_raw_tags%5D%5B%5D=sourced');
       // Skillsets use custom_hierarchy_1
@@ -587,6 +588,53 @@ describe('Loxo MCP tool handlers', () => {
       expect(capturedBody).toContain('person%5Bperson_type_id%5D=80073');
       // Source type
       expect(capturedBody).toContain('person%5Bsource_type_id%5D=1206583');
+    });
+
+    it('sends PUT with person[raw_tags][] (additive) by default, NOT person[all_raw_tags][]', async () => {
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({
+            person: { id: 42, name: 'Jane Smith', all_raw_tags: 'existing-tag, debt-advisory' }
+          })),
+        });
+      }));
+
+      const result = await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        tags: ['debt-advisory', 'new-tag'],
+      });
+
+      expect(result.isError).toBeFalsy();
+      // Default is additive: raw_tags[], NOT all_raw_tags[]
+      expect(capturedBody).toContain('person%5Braw_tags%5D%5B%5D=debt-advisory');
+      expect(capturedBody).toContain('person%5Braw_tags%5D%5B%5D=new-tag');
+      expect(capturedBody).not.toContain('person%5Ball_raw_tags%5D%5B%5D');
+    });
+
+    it('sends PUT with person[all_raw_tags][] (replace) when replace_tags=true', async () => {
+      let capturedBody = '';
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: any) => {
+        capturedBody = opts?.body || '';
+        return Promise.resolve({
+          ok: true, status: 200, statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify({
+            person: { id: 42, name: 'Jane Smith', all_raw_tags: 'replaced-tag' }
+          })),
+        });
+      }));
+
+      const result = await callTool(client, 'loxo_update_candidate', {
+        id: '42',
+        tags: ['replaced-tag'],
+        replace_tags: true,
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedBody).toContain('person%5Ball_raw_tags%5D%5B%5D=replaced-tag');
+      expect(capturedBody).not.toContain('person%5Braw_tags%5D%5B%5D');
     });
 
     it('returns error when only id is provided (empty body guard)', async () => {


### PR DESCRIPTION
## Summary

- Fixes tag-write footgun: `loxo_update_candidate` was destructive by default (writing `person[all_raw_tags][]`), silently wiping all existing tags. Now defaults to additive (`person[raw_tags][]`); pass `replace_tags: true` to opt into destructive replace.
- Adds compensation field support: `salary`, `compensation`, `compensation_currency_id`, `salary_type_id`, `bonus`, `description`.
- Adds `extra_fields` map for arbitrary top-level person fields (built-in or tenant-specific dynamic), sent as `person[<key>]` form params with schema-cache + safe-key validation. Array values become repeated `person[<key>][]=<v>` entries (Hierarchy fields like `skillset_ids`, `sector_ids`, `custom_hierarchy_*`).
- Annotates `destructiveHint: true` on `loxo_update_candidate` to reflect the worst-case (replace-mode) destructive behaviour. Refreshes the tool description to advertise the new capabilities.
- Bumps to v1.8.0 (additive feature minor).

Required by the Loxo Auto-Update from Ringover workflow in n8n-workflows (spec: `docs/specs/2026-05-03-loxo-auto-update-from-ringover-design.md`).

## Test plan

- [x] New unit tests cover both append and replace tag paths
- [x] New unit tests cover all six compensation fields
- [x] New unit tests cover extra_fields happy path, key validation, and array-value path
- [x] Pre-existing test updated to use `replace_tags: true` where it relied on the old destructive default
- [x] `npm test` clean (118/118)
- [x] `npm run lint` clean (0 errors)
- [x] `npm run build` clean
- [x] Live API test: confirmed `person[raw_tags][]` is additive (see n8n-workflows `docs/notes/2026-05-03-loxo-raw-tags-semantics.md`)
- [x] Live API test: confirmed dynamic field values land at top level on person GET (see n8n-workflows `docs/notes/2026-05-03-loxo-dynamic-fields.md`)

## Notes

- Schema-cache validation reads `globalThis.LOXO_PERSON_KEY_CACHE` and falls back to a regex when the cache is absent. The cache loader (populating that global at server startup from `GET /dynamic_fields`) is intentionally out of scope for this PR; tracked separately.
- Includes a small chore commit syncing `package-lock.json` to the existing 1.7.1 version (drift left over from a prior release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)